### PR TITLE
fix handling of empty tool response

### DIFF
--- a/lua/mcphub/extensions/codecompanion/utils.lua
+++ b/lua/mcphub/extensions/codecompanion/utils.lua
@@ -161,6 +161,14 @@ function M.create_output_handlers(action_name, has_function_calling, opts)
                     result.text
                 )
                 add_tool_output(action_name, self, agent.chat, to_llm, false, has_function_calling, opts)
+            else
+                -- When a tool returns no text content, still send a message to
+                -- ensure the tool_call_id protocol is satisfied
+                local to_llm = string.format(
+                    "**`%s` Tool**: Completed with no output",
+                    action_name
+                )
+                add_tool_output(action_name, self, agent.chat, to_llm, false, has_function_calling, opts)
             end
             -- TODO: Add image support when codecompanion supports it
         end,


### PR DESCRIPTION
## Summary
- ensure `codecompanion` integration always emits a message for tool calls

## Testing
- `make test` *(fails: couldn't connect to github to download plenary.nvim)*
- `make format` *(fails: stylua not found)*